### PR TITLE
fix: Update app URL format to use HTTPS

### DIFF
--- a/lib/helper/appUrl.ts
+++ b/lib/helper/appUrl.ts
@@ -1,4 +1,4 @@
 export function getAppUrl(path:string){
     const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-    return `${appUrl}/${path}`
+    return `https://${appUrl}/${path}`
 }


### PR DESCRIPTION
- Change the app URL construction in getAppUrl function to prepend 'https://' to the base URL, ensuring secure connections.